### PR TITLE
Add an option to send users to the signup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ config.omniauth :mediawiki, CONSUMER_KEY, CONSUMER_SECRET,
                 client_options: {:site => 'https://commons.wikimedia.org' }
 ```
 
-You can also use the `signup` option to configure it to direct users to the MediaWiki account creation page:
+You can also use the `signup` option to configure it to direct users to the MediaWiki account creation page. Use `signup_params` to optionally add parameters to the account creation URL.
 
 ```ruby
 config.omniauth :mediawiki_signup, CONSUMER_KEY, CONSUMER_SECRET,
@@ -44,7 +44,8 @@ config.omniauth :mediawiki_signup, CONSUMER_KEY, CONSUMER_SECRET,
                 strategy_class: OmniAuth::Strategies::Mediawiki,
                 client_options: {
                   site: 'https://en.wikipedia.org',
-                  signup: true
+                  signup: true,
+                  signup_params: { geEnabled: 1, geForceVariant: 'control' }
                 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,28 +7,46 @@ MediaWiki uses the OAuth 1.0a extension, you can read about it here: https://www
 
 ## How To Use It
 
-Usage is as per any other OmniAuth 1.0 strategy. So let's say you're using Rails, you need to add the strategy to your `Gemfile` along side omniauth:
+Usage is as per any other OmniAuth 1.0 strategy. So let's say you're using Rails, you need to add the strategy to your `Gemfile` alongside omniauth:
 
-    gem 'omniauth'
-    gem 'omniauth-mediawiki'
+```ruby
+gem 'omniauth'
+gem 'omniauth-mediawiki'
+```
 
 Of course if one or both of these are unreleased, you may have to pull them in directly from github e.g.:
 
-    gem 'omniauth', :git => 'https://github.com/intridea/omniauth.git'
-    gem 'omniauth-mediawiki', :git => 'https://github.com/timwaters/omniauth-mediawiki.git'
+```ruby
+gem 'omniauth', :git => 'https://github.com/intridea/omniauth.git'
+gem 'omniauth-mediawiki', :git => 'https://github.com/timwaters/omniauth-mediawiki.git'
+```
 
-Once these are in, you need to add the following to your `config/initializers/omniauth.rb`:
+Once these are in, you need to add the following to your `config/initializers/omniauth.rb` (with your key and secret, which you get when you register your app on your particular wiki):
 
-    Rails.application.config.middleware.use OmniAuth::Builder do
-      provider :mediawiki, "consumer_key", "consumer_secret"
-    end
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :mediawiki, CONSUMER_KEY, CONSUMER_SECRET
+end
+```
 
 If you are using devise, this is how it looks like in your `config/initializers/devise.rb`:
 
-    config.omniauth :mediawiki, "consumer_key", "consumer_secret", 
-                    {:client_options => {:site => 'https://commons.wikimedia.org' }}
+```ruby
+config.omniauth :mediawiki, CONSUMER_KEY, CONSUMER_SECRET,
+                client_options: {:site => 'https://commons.wikimedia.org' }
+```
 
-You will obviously have to put in your key and secret, which you get when you register your app on your particula Wiki.
+You can also use the `signup` option to configure it to direct users to the MediaWiki account creation page:
+
+```ruby
+config.omniauth :mediawiki_signup, CONSUMER_KEY, CONSUMER_SECRET,
+                name: 'mediawiki_signup',
+                strategy_class: OmniAuth::Strategies::Mediawiki,
+                client_options: {
+                  site: 'https://en.wikipedia.org',
+                  signup: true
+                }
+```
 
 Now just follow the README at: https://github.com/intridea/omniauth
 
@@ -38,27 +56,33 @@ In general see the pages around https://www.mediawiki.org/wiki/OAuth/For_Develop
 
 When registering for a new OAuth consumer registration you need to specify the callback url properly. e.g. for development:
 
-    http://localhost:3000/u/auth/mediawiki/callback 
+    http://localhost:3000/u/auth/mediawiki/callback
     http://localhost:3000/users/auth/mediawiki/callback
-    
-Internally the strategy has to use  `/w/index.php?title=`  paths like so:
 
-    :authorize_path => '/wiki/Special:Oauth/authorize',
-    :access_token_path => '/w/index.php?title=Special:OAuth/token',
-    :request_token_path => '/w/index.php?title=Special:OAuth/initiate',
-    
-This is a workaround as the paths should all be like the authorize path.
+Internally the strategy has to use `/w/index.php?title=` paths like so:
 
-Note also that new proposed registrations on mediawiki.org will work with your mediawki user that you registered the application with but have to be approved by an admin user for them to be useable by other users. 
+```ruby
+:authorize_path => '/w/index.php',
+:authorize_path_params => { :title => 'Special:OAuth/authorize' },
+:access_token_path => '/w/index.php?title=Special:OAuth/token',
+:request_token_path => '/w/index.php?title=Special:OAuth/initiate',
+```
+
+The initial path to the wiki can be modified by passing in alternative values for `:authorize_path_params`, in which case, 'Special:OAuth/authorize' will be passed as
+the `returnto` parameter, and the oauth keys will be passed into a `returntoquery` parameter.
+
+Note also that new proposed registrations on mediawiki.org will work with your mediawki user that you registered the application with but have to be approved by an admin user for them to be usable by other users.
 
 ## Specifying Target Wiki
 
-If you would like to use this plugin against a wiki you should pass this you can use the environment variable WIKI_AUTH_SITE to set the server to connect to. Alternatively you can pass the site as a client_option to the omniauth config:
+If you would like to use this plugin against a wiki you can use the environment variable WIKI_AUTH_SITE to set the server to connect to. Alternatively you can pass the site as a client_option to the omniauth config:
 
-    config.omniauth :mediawiki, "consumer_key", "consumer_secret",  
-                    :client_options => {:site => 'https://commons.wikimedia.org' }
+```ruby
+config.omniauth :mediawiki, "consumer_key", "consumer_secret",  
+                :client_options => {:site => 'https://commons.wikimedia.org' }
+```
 
-if no site is specified the www.mediawiki.org wiki will be used.
+If no site is specified the www.mediawiki.org wiki will be used.
 
 ## How to call the MediaWiki API via Omniauth
 
@@ -66,12 +90,30 @@ Within a Devise / Omniauth setup, in the callback method, you can directly get a
 
 Assuming these are stored in the user model, the following could be used to query the mediawiki API at a later date. In this example we are using the Wikimedia Commons API https://www.mediawiki.org/wiki/API:Main_page
 
-    @consumer = OAuth::Consumer.new "consumer_key",  "consumer_secret",  
-                        {:site=>"https://commons.wikimedia.org"}
-    @access_token = OAuth::AccessToken.new(@consumer, user.auth_token, user.auth_secret) 
-    uri = 'https://commons.wikimedia.org/w/api.php?action=query&meta=userinfo&uiprop=rights|editcount&format=json'
-    resp = @access_token.get(URI.encode(uri))
-    logger.debug resp.body.inspect
-    # {"query":{"userinfo":{"id":12345,"name":"WikiUser",
-    # "rights":["read","writeapi","purge","autoconfirmed","editsemiprotected","skipcaptcha"],
-    # "editcount":2323}}}
+```ruby
+@consumer = OAuth::Consumer.new "consumer_key",  "consumer_secret",  
+                                {:site=>"https://commons.wikimedia.org"}
+@access_token = OAuth::AccessToken.new(@consumer, user.auth_token, user.auth_secret)
+uri = 'https://commons.wikimedia.org/w/api.php?action=query&meta=userinfo&uiprop=rights|editcount&format=json'
+resp = @access_token.get(URI.encode(uri))
+logger.debug resp.body.inspect
+# {"query":{"userinfo":{"id":12345,"name":"WikiUser",
+# "rights":["read","writeapi","purge","autoconfirmed","editsemiprotected","skipcaptcha"],
+# "editcount":2323}}}
+```
+
+## Integration testing
+
+If you want to use the OAuth authorization flow in integration tests, you need to short-circuit the callback step of the process, like this:
+
+```ruby
+OmniAuth.config.test_mode = true
+allow_any_instance_of(OmniAuth::Strategies::Mediawiki)
+  .to receive(:callback_url).and_return('/users/auth/mediawiki/callback')
+OmniAuth.config.mock_auth[:mediawiki] = OmniAuth::AuthHash.new(
+  provider: 'mediawiki',
+  uid: '12345',
+  info: { name: 'TestUser' },
+  credentials: { token: 'foo', secret: 'bar' }
+)
+```

--- a/lib/omniauth/strategies/mediawiki.rb
+++ b/lib/omniauth/strategies/mediawiki.rb
@@ -15,10 +15,11 @@ module OmniAuth
         end
       end
 
-
       option :client_options, {
         :site => site,
-        :authorize_path => '/wiki/Special:Oauth/authorize',
+        :signup => false,
+        :authorize_path => '/w/index.php',
+        :authorize_path_title => 'Special:OAuth/authorize',
         :access_token_path => '/w/index.php?title=Special:OAuth/token',
         :request_token_path => '/w/index.php?title=Special:OAuth/initiate',
         :oauth_callback=> "oob"
@@ -31,9 +32,7 @@ module OmniAuth
         r = Rack::Response.new
 
         if request_token.callback_confirmed?
-          r.redirect(request_token.authorize_url(
-                       :oauth_consumer_key => consumer.key
-          ))
+          r.redirect(request_token.authorize_url(authorize_url_parameters))
         else
           r.redirect(request_token.authorize_url(
                        :oauth_callback => callback_url,
@@ -68,22 +67,44 @@ module OmniAuth
         }
       end
 
-
       def raw_info
         @raw_info ||= parse_info(access_token.get('/w/index.php?title=Special:OAuth/identify'))
 
         @raw_info
       end
-      
+
       private
-      
+
+      def authorize_url_parameters
+        params = { :title => consumer.options[:authorize_path_title] }
+
+        if consumer.options[:signup]
+          params.merge!(
+            :title => 'Special:UserLogin',
+            :type => 'signup'
+          )
+        end
+
+        # To preserve the oauth keys and redirect the user to authorization
+        # after account creation, the oauth parameters must be put into
+        # a returntoquery parameter, unless the user goes directly to
+        # Special:OAuth/authorize
+        if params[:title] == 'Special:OAuth/authorize'
+          params.merge!(:oauth_consumer_key => consumer.key)
+        else
+          params.merge!(
+            :returnto => 'Special:OAuth/authorize',
+            :returntoquery => "oauth_consumer_key=#{consumer.key}"
+          )
+        end
+      end
+
       def parse_info(jwt_data)
         ident = jwt_data.body
         payload, header = JWT.decode(ident, consumer.secret)
-        
+
         payload
       end
-
     end
   end
 end

--- a/lib/omniauth/strategies/mediawiki.rb
+++ b/lib/omniauth/strategies/mediawiki.rb
@@ -133,9 +133,10 @@ module OmniAuth
         payload, _header = JWT.decode(ident, consumer.secret)
 
         payload
-      rescue JWT::DecodeError
+      rescue JWT::DecodeError => e
         fail!(:login_error)
         return { login_failed: true,
+                 error: e,
                  jwt_data: jwt_data.body }
       end
     end

--- a/lib/omniauth/strategies/mediawiki.rb
+++ b/lib/omniauth/strategies/mediawiki.rb
@@ -110,6 +110,12 @@ module OmniAuth
           )
         end
 
+        # The consumer can be configured to add a parameter to the
+        # signup URL, for example, geEnabled=0 to disable Growth features.
+        if consumer.options[:signup_params]
+          params.merge!(consumer.options[:signup_params])
+        end
+
         # To preserve the oauth keys and redirect the user to authorization
         # after account creation, the oauth parameters must be put into
         # a returntoquery parameter, unless the user goes directly to

--- a/omniauth-mediawiki.gemspec
+++ b/omniauth-mediawiki.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{|f| File.basename(f)}
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency "omniauth-oauth", "~> 1.0"
+  gem.add_runtime_dependency "omniauth-oauth"
   gem.add_runtime_dependency "jwt", "~> 2.0"
 
   gem.add_development_dependency 'rake', '~> 0.9'

--- a/omniauth-mediawiki.gemspec
+++ b/omniauth-mediawiki.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |gem|
   gem.summary     = %q{Mediawiki strategy for OmniAuth 1.0a for wikipedia.org, commons.wikimedia.org etc where the wiki has the OAuth extension installed}
   gem.license     = 'MIT'
 
-  gem.rubyforge_project = "omniauth-mediawiki"
-
   gem.files       = `git ls-files`.split("\n")
   gem.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.executables = `git ls-files -- bin/*`.split("\n").map{|f| File.basename(f)}

--- a/omniauth-mediawiki.gemspec
+++ b/omniauth-mediawiki.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency "omniauth-oauth", "~> 1.0"
-  gem.add_runtime_dependency "jwt", "~> 1.0"
+  gem.add_runtime_dependency "jwt", "~> 2.0"
 
   gem.add_development_dependency 'rake', '~> 0.9'
   gem.add_development_dependency 'rspec', '~> 2.7'

--- a/spec/omniauth/strategies/mediawiki_spec.rb
+++ b/spec/omniauth/strategies/mediawiki_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe OmniAuth::Strategies::Mediawiki do
-  subject do
-    OmniAuth::Strategies::Mediawiki.new({})
-  end
+  context 'default client options' do
+    subject do
+      OmniAuth::Strategies::Mediawiki.new('mediawiki', client_options: {})
+    end
 
-  context 'client options' do
     it 'should have correct name' do
       expect(subject.options.name).to eq('mediawiki')
     end
@@ -15,7 +15,8 @@ describe OmniAuth::Strategies::Mediawiki do
     end
 
     it 'should have correct authorize url' do
-      expect(subject.options.client_options.authorize_path).to eq('/wiki/Special:Oauth/authorize')
+      expect(subject.options.client_options.authorize_path).to eq('/w/index.php')
+      expect(subject.options.client_options.authorize_path_title).to eq('Special:OAuth/authorize')
     end
 
     it 'should have correct access token url' do
@@ -24,6 +25,36 @@ describe OmniAuth::Strategies::Mediawiki do
 
     it 'should have correct request token url' do
       expect(subject.options.client_options.request_token_path).to eq('/w/index.php?title=Special:OAuth/initiate')
+    end
+  end
+
+  context 'signup client true' do
+    subject do
+      OmniAuth::Strategies::Mediawiki
+        .new('mediawiki', client_options: { signup: true })
+        .send(:authorize_url_parameters)
+    end
+
+    it 'should set up url params to go to signup and redirect to authorize url' do
+      expect(subject[:title]).to eq 'Special:UserLogin'
+      expect(subject[:type]).to eq 'signup'
+      expect(subject[:returnto]).to eq 'Special:OAuth/authorize'
+      expect(subject[:returntoquery]).to match /oauth_consumer_key=.*/
+    end
+  end
+
+  context 'authorize_path_title set manually' do
+    subject do
+      OmniAuth::Strategies::Mediawiki
+        .new('mediawiki', client_options: { authorize_path_title: 'Special:UserLogin' })
+        .send(:authorize_url_parameters)
+    end
+
+    it 'should set up url params to requested title and redirect to authorize url' do
+      expect(subject[:title]).to eq 'Special:UserLogin'
+      expect(subject[:type]).to be_nil
+      expect(subject[:returnto]).to eq 'Special:OAuth/authorize'
+      expect(subject[:returntoquery]).to match /oauth_consumer_key=.*/
     end
   end
 end


### PR DESCRIPTION
This patch adds a new client option, `signup`, which will configure the strategy to go directly to the account creation page, instead of starting at the Special:OAuth/authorize page. That way, if users know they don't have an account and will need to create one in order to use the OAuth app, they can skip needing to find their way from the login page over the the account creation page.

Also, this updates and formats the docs.
