### PR TITLE
Extract the email address from raw_info

### DIFF
--- a/lib/omniauth/strategies/mediawiki.rb
+++ b/lib/omniauth/strategies/mediawiki.rb
@@ -58,6 +58,7 @@ module OmniAuth
       info do
         {
           :name => raw_info["username"],
+          :email => raw_info["email"],
           :urls => {"server" => raw_info["iss"]}
         }
       end


### PR DESCRIPTION
This copies the email address from `raw_info` to the standard place in the main `info` hash.
