### PR TITLE
Simplify mediawiki authentication

### DIFF
--- a/lib/omniauth/strategies/mediawiki.rb
+++ b/lib/omniauth/strategies/mediawiki.rb
@@ -20,33 +20,8 @@ module OmniAuth
         :site => site,
         :authorize_path => '/wiki/Special:Oauth/authorize',
         :access_token_path => '/w/index.php?title=Special:OAuth/token',
-        :request_token_path => '/w/index.php?title=Special:OAuth/initiate',
-        :oauth_callback=> "oob"
+        :request_token_path => '/w/index.php?title=Special:OAuth/initiate'
       }
-
-      def request_phase
-        request_token = consumer.get_request_token(:oauth_callback => callback_url)
-        session['oauth'] ||= {}
-        session['oauth'][name.to_s] = {'callback_confirmed' => request_token.callback_confirmed?, 'request_token' => request_token.token, 'request_secret' => request_token.secret}
-        r = Rack::Response.new
-
-        if request_token.callback_confirmed?
-          r.redirect(request_token.authorize_url(
-                       :oauth_consumer_key => consumer.key
-          ))
-        else
-          r.redirect(request_token.authorize_url(
-                       :oauth_callback => callback_url,
-                       :oauth_consumer_key => consumer.key
-          ))
-        end
-
-        r.finish
-      end
-
-      def callback_url
-        'oob'
-      end
 
       # These are called after authentication has succeeded. If
       # possible, you should try to set the UID without making


### PR DESCRIPTION
This removes the seeming unnecessary overiding of request_phase
reducing the risk of diverging from the parent class version which
it was largely copied from.

It also removed the override of callback_url in favour of using
the default, which requests a callback to the correct omniauth
callback rather than requesting out-of-band callback which seems
wrong for a web authentication framework.

This has been tested - you need to make sure you specify the right
callback prefix and enable callback URLs when creating the consumer
at the mediawiki end but so long as you do that it works fine.
