### PR TITLE
Bump jwt version to 2.x

### DIFF
--- a/omniauth-mediawiki.gemspec
+++ b/omniauth-mediawiki.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency "omniauth-oauth", "~> 1.0"
-  gem.add_runtime_dependency "jwt", "~> 1.0"
+  gem.add_runtime_dependency "jwt", "~> 2.0"
 
   gem.add_development_dependency 'rake', '~> 0.9'
   gem.add_development_dependency 'rspec', '~> 2.7'


### PR DESCRIPTION
This is needed for openstreetmap.org as we have both omniauth-google-oauth2 and omniauth-mediawiki installed and the latest version of omniauth-google-oauth2 requires jwt 2.x which creates a conflict when resolving the bundle.

I don't think there are any compatibility issues - in omniauth-google-oauth2 they had to manually verify the claims after the decode because they are passing false for verification when decoding and jwt 2.x no longer verifies the claims in that case but that doesn't apply here.